### PR TITLE
Use real UID for log file

### DIFF
--- a/criu/log.c
+++ b/criu/log.c
@@ -228,6 +228,12 @@ int log_init(const char *output)
 		}
 	}
 
+	// The file was opened with effective UID, which is usually root (due to suid bit)
+	// To make debugging more convenient we'll try to change that to real UID.
+	if (fchown(new_logfd, getuid(), -1)) {
+		pr_warn("Cannot change ownership of the log file.");
+	}
+
 	fd = install_service_fd(LOG_FD_OFF, new_logfd);
 	if (fd < 0)
 		goto err;

--- a/criu/log.c
+++ b/criu/log.c
@@ -231,7 +231,7 @@ int log_init(const char *output)
 	// The file was opened with effective UID, which is usually root (due to suid bit)
 	// To make debugging more convenient we'll try to change that to real UID.
 	if (fchown(new_logfd, getuid(), -1)) {
-		pr_warn("Cannot change ownership of the log file.");
+		pr_warn("Cannot change ownership of the log file: %s", strerror(errno));
 	}
 
 	fd = install_service_fd(LOG_FD_OFF, new_logfd);


### PR DESCRIPTION
The log file is opened with effective UID, which is usually root (due to suid bit we usually use). To make debugging more convenient we'll try to change that to the real UID.