### PR TITLE
Make criu handle Azure environment correctly

### DIFF
--- a/criu/kerndat.c
+++ b/criu/kerndat.c
@@ -1006,14 +1006,10 @@ static int kerndat_has_move_mount_set_group(void)
 	}
 
 	if (mount("criu.move_mount_set_group", tmpdir, "tmpfs", 0, NULL)) {
-		if (errno == EPERM) {
-			kdat.has_move_mount_set_group = false;
-			rmdir(tmpdir);
-			return 0;
-		}
-		pr_perror("Fail to mount tmfps to %s", tmpdir);
+		pr_warn("Fail to mount tmfps to %s: %m\n", tmpdir);
+		kdat.has_move_mount_set_group = false;
 		rmdir(tmpdir);
-		return -1;
+		return 0;
 	}
 
 	if (mount(NULL, tmpdir, NULL, MS_PRIVATE, NULL)) {


### PR DESCRIPTION
Assume all mount errors are caused by unsufficient privilges and try to restore anyway.

This fixes restore in the Azure environment, which returns EACCESS in attempt to mount().