### PR TITLE
Disabled seccomp functionality with macro

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,6 +247,8 @@ criu-deps	+= $(SOCCR_A)
 #
 LZ4_OBJS = lz4/lib/liblz4.a criu/liblz4io.a
 $(LZ4_OBJS) :
+	git submodule init
+	git submodule update
 	$(Q) env -i PATH=$$PATH make CC=$(CC) CFLAGS="$(CFLAGS)" -C lz4 lib lz4
 	$(Q) $(AR) rcs criu/liblz4io.a lz4/programs/lz4io.o
 

--- a/compel/src/lib/infect.c
+++ b/compel/src/lib/infect.c
@@ -73,12 +73,14 @@ static int parse_pid_status(int pid, struct seize_task_status *ss, void *data)
 			continue;
 		}
 
+#ifdef ENABLE_SECCOMP
 		if (!strncmp(aux, "Seccomp:", 8)) {
 			if (sscanf(aux + 9, "%d", &ss->seccomp_mode) != 1)
 				goto err_parse;
 
 			continue;
 		}
+#endif //ENABLE_SECCOMP
 
 		if (!strncmp(aux, "ShdPnd:", 7)) {
 			if (sscanf(aux + 7, "%llx", &ss->shdpnd) != 1)

--- a/criu/proc_parse.c
+++ b/criu/proc_parse.c
@@ -1117,6 +1117,7 @@ int parse_pid_status(pid_t pid, struct seize_task_status *ss, void *data)
 			continue;
 		}
 
+#ifdef ENABLE_SECCOMP
 		if (!strncmp(str, "Seccomp:", 8)) {
 			if (sscanf(str + 9, "%d", &cr->s.seccomp_mode) != 1) {
 				goto err_parse;
@@ -1126,6 +1127,7 @@ int parse_pid_status(pid_t pid, struct seize_task_status *ss, void *data)
 			done++;
 			continue;
 		}
+#endif //ENABLE_SECCOMP
 
 		if (!strncmp(str, "ShdPnd:", 7)) {
 			unsigned long long sigpnd;


### PR DESCRIPTION
When using CRaC with Docker for Windows, there may be the issue with seccomp permissions in criu, even if "`--privileged`" docker option is set. For example, see https://github.com/checkpoint-restore/criu/issues/1666#issuecomment-981620691
The "`--security-opt seccomp=unconfined`" may be used as a workaround, but Docker seems to have this option broken time to time.

We could disable seccomp-related functionality in criu, because CRaC doesn't need it.
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
