### PR TITLE
Backport of optional MFD_HUGETLB support on Raspberry Pi

### DIFF
--- a/criu/kerndat.c
+++ b/criu/kerndat.c
@@ -502,7 +502,7 @@ static bool kerndat_has_memfd_hugetlb(void)
 	if (ret >= 0) {
 		kdat.has_memfd_hugetlb = true;
 		close(ret);
-	} else if (ret == -1 && (errno == EINVAL || errno == ENOENT)) {
+	} else if (ret == -1 && (errno == EINVAL || errno == ENOENT || errno == ENOSYS)) {
 		kdat.has_memfd_hugetlb = false;
 	} else {
 		pr_perror("Unexpected error from memfd_create(\"\", MFD_HUGETLB)");


### PR DESCRIPTION
Clean cherry-pick from upstream to make it compatible with the most of RPi kernels. 