### PR TITLE
Port unprivileged restore to aarch64

### DIFF
--- a/criu/arch/aarch64/include/asm/restorer.h
+++ b/criu/arch/aarch64/include/asm/restorer.h
@@ -30,6 +30,15 @@
 			"b   clone_end					\n"	\
 										\
 			"thread_run:					\n"	\
+		        "mov x8, #"__stringify(__NR_gettid)"       	\n"	\
+			"svc #0						\n"	\
+			"cmp x0, %7					\n" 	\
+			"beq cont					\n" 	\
+			"mov x0, #2					\n" 	\
+			"mov x8, #"__stringify(__NR_exit)"		\n"	\
+			"svc #0						\n"	\
+										\
+			"cont:						\n" 	\
 			"ldp x1, x0, [sp]				\n"	\
 			"br  x1						\n"	\
 										\
@@ -40,7 +49,8 @@
 			  "r"(&parent_tid),					\
 			  "r"(&thread_args[i].pid),				\
 			  "r"(clone_restore_fn),				\
-			  "r"(&thread_args[i])					\
+			  "r"(&thread_args[i]),					\
+		          "r"(thread_args[i].pid)                               \
 			: "x0", "x1", "x2", "x3", "x8", "memory")
 
 /*

--- a/criu/arch/x86/include/asm/restorer.h
+++ b/criu/arch/x86/include/asm/restorer.h
@@ -68,13 +68,13 @@ static inline int set_compat_robust_list(uint32_t head_ptr, uint32_t len)
 		     "thread_run:				\n"	\
 		     "movl $"__stringify(__NR_gettid)", %%eax	\n"	\
 		     "syscall					\n"	\
-		     "cmpq %%rax, %7 \n" \
-		     "je cont \n" \
-		     "mov $2, %%rdi \n" \
+		     "cmpq %%rax, %7 				\n" 	\
+		     "je cont					\n" 	\
+		     "mov $2, %%rdi				\n" 	\
 		     "movl $"__stringify(__NR_exit)", %%eax	\n"	\
 		     "syscall					\n"	\
 									\
-		     "cont:\n" \
+		     "cont:					\n" 	\
 		     "xorq %%rbp, %%rbp				\n"	\
 		     "movq 0(%%rsp), %%rax			\n"	\
 		     "movq 8(%%rsp), %%rdi			\n"	\


### PR DESCRIPTION
In https://github.com/CRaC/criu/commit/db457a80298fca7963c1477b7a95ab4d46ce2885#diff-fb13ab02aee7015f7bb504cd1a63741ac942b7ad2a7ec6e3b4a9740fb10bde9dR66 (Restore in unprivileged environments), when we need to create a thread with certain TID, we spawn a limited set of threads until one of them eventually reach the target TID. But we need to ensure that those threads whose TIDs are below the target TID do not interfere with the thread with the target TID. All threads may co-exist for a short amount of time due to scheduling policies, and during that time, they share the stack. 

So we need to port changes from x86-64 to have uniform behavior across platforms.

This change is also expected to fix an intermittent crash on restore on aarch64.