### PR TITLE
Use read_all/pread_all where we expect full buffer to be read

### DIFF
--- a/criu/apparmor.c
+++ b/criu/apparmor.c
@@ -141,7 +141,7 @@ static int collect_profile(char *path, int offset, char *dir, AaNamespace *ns)
 	if (!cur->blob.data)
 		goto close;
 
-	n = read(fd, cur->blob.data, sb.st_size);
+	n = read_all(fd, cur->blob.data, sb.st_size);
 	if (n < 0) {
 		pr_perror("failed to read %s", path);
 		goto close;

--- a/criu/cr-dump.c
+++ b/criu/cr-dump.c
@@ -467,7 +467,7 @@ static int get_task_auxv(pid_t pid, MmEntry *mm)
 	if (fd < 0)
 		return -1;
 
-	ret = read(fd, mm_saved_auxv, sizeof(mm_saved_auxv));
+	ret = read_all(fd, mm_saved_auxv, sizeof(mm_saved_auxv));
 	if (ret < 0) {
 		ret = -1;
 		pr_perror("Error reading %d's auxv", pid);

--- a/criu/files-reg.c
+++ b/criu/files-reg.c
@@ -1576,7 +1576,7 @@ static int get_build_id(const int fd, const struct stat *fd_status, unsigned cha
 	size_t mapped_size;
 	int ret = -1;
 
-	if (read(fd, buf, SELFMAG + 1) != SELFMAG + 1)
+	if (read_all(fd, buf, SELFMAG + 1) != SELFMAG + 1)
 		return -1;
 
 	/*

--- a/criu/include/util.h
+++ b/criu/include/util.h
@@ -388,6 +388,7 @@ extern char *get_legacy_iptables_bin(bool ipv6);
 
 extern ssize_t read_all(int fd, void *buf, size_t size);
 extern ssize_t write_all(int fd, const void *buf, size_t size);
+extern ssize_t pread_all(int fd, void *buf, size_t size, off_t offset);
 
 #define cleanup_free __attribute__((cleanup(cleanup_freep)))
 static inline void cleanup_freep(void *p)

--- a/criu/ipc_ns.c
+++ b/criu/ipc_ns.c
@@ -790,26 +790,20 @@ err:
 static int restore_content(void *data, struct cr_img *img, const IpcShmEntry *shm)
 {
 	int ifd;
-	ssize_t size, off;
+	ssize_t size, ret;
 
 	ifd = img_raw_fd(img);
 	if (ifd < 0) {
 		pr_err("Failed getting raw image fd\n");
 		return -1;
 	}
+
 	size = round_up(shm->size, sizeof(u32));
-	off = 0;
-	do {
-		ssize_t ret;
-
-		ret = read(ifd, data + off, size - off);
-		if (ret <= 0) {
-			pr_perror("Failed to write IPC shared memory data");
-			return (int)ret;
-		}
-
-		off += ret;
-	} while (off < size);
+	ret = read_all(ifd, data, size);
+	if (ret != size) {
+		pr_perror("Failed to write IPC shared memory data");
+		return (int)ret;
+	}
 
 	return 0;
 }

--- a/criu/ipc_ns.c
+++ b/criu/ipc_ns.c
@@ -802,7 +802,7 @@ static int restore_content(void *data, struct cr_img *img, const IpcShmEntry *sh
 	ret = read_all(ifd, data, size);
 	if (ret != size) {
 		pr_perror("Failed to write IPC shared memory data");
-		return (int)ret;
+		return -1;
 	}
 
 	return 0;

--- a/criu/kerndat.c
+++ b/criu/kerndat.c
@@ -71,7 +71,7 @@ static int check_pagemap(void)
 	}
 
 	/* Get the PFN of some present page. Stack is here, so try it :) */
-	ret = pread(fd, &pfn, sizeof(pfn), (((unsigned long)&ret) / page_size()) * sizeof(pfn));
+	ret = pread_all(fd, &pfn, sizeof(pfn), (((unsigned long)&ret) / page_size()) * sizeof(pfn));
 	if (ret != sizeof(pfn)) {
 		pr_perror("Can't read pagemap");
 		return -1;
@@ -1090,7 +1090,7 @@ static int kerndat_try_load_cache(void)
 		return 1;
 	}
 
-	ret = read(fd, &kdat, sizeof(kdat));
+	ret = read_all(fd, &kdat, sizeof(kdat));
 	if (ret < 0) {
 		pr_perror("Can't read kdat cache");
 		close(fd);
@@ -1361,7 +1361,7 @@ static int kerndat_has_pidfd_getfd(void)
 		goto close_all;
 	}
 
-	if (read(fds[1], &val_b, sizeof(val_b)) != sizeof(val_b)) {
+	if (read_all(fds[1], &val_b, sizeof(val_b)) != sizeof(val_b)) {
 		pr_perror("Can't read from socket");
 		ret = -1;
 		goto close_all;

--- a/criu/pagemap-cache.c
+++ b/criu/pagemap-cache.c
@@ -153,7 +153,7 @@ static int pmc_fill_cache(pmc_t *pmc, const struct vma_area *vma)
 	BUG_ON(pmc->map_len < size_map);
 	BUG_ON(pmc->fd < 0);
 
-	if (pread(pmc->fd, pmc->map, size_map, PAGEMAP_PFN_OFF(pmc->start)) != size_map) {
+	if (pread_all(pmc->fd, pmc->map, size_map, PAGEMAP_PFN_OFF(pmc->start)) != size_map) {
 		pmc_zap(pmc);
 		pr_perror("Can't read %d's pagemap file", pmc->pid);
 		return -1;


### PR DESCRIPTION
I've found that some GHA's in OpenJDK/crac are failing due to this error, and I think I've seen that even locally (on ia32) though rarely:

```
(00.040592) Error (criu/pagemap-cache.c:158): pagemap-cache: Can't read 9142's pagemap file: No such file or directory
(00.040595) Error (criu/pagemap-cache.c:173): pagemap-cache: Failed to fill cache for 9142 (ffe3b000-ffe3c000)
(00.040617) page-pipe: Killing page pipe
(00.040798) ----------------------------------------
(00.040804) Error (criu/mem.c:625): Can't dump page with parasite
```

Turns out that some parts of code use `read(...)` or `pread(...)` without handling that the call returns less bytes than the full size of the buffer; I've replaced those places where the expectation is obvious (error message if the returned value does not match buffer size) with `read_all` and new `pread_all` utility function. 