### PR TITLE
Fix inheriting standard descriptors

### DIFF
--- a/criu/files.c
+++ b/criu/files.c
@@ -855,6 +855,7 @@ int collect_fd(int pid, FdinfoEntry *e, struct rst_info *rst_info, bool fake)
 	if (!collect_fd_to(pid, e, rst_info, fdesc, fake, false))
 		return -1;
 
+	snprintf(inh_id, sizeof(inh_id), "fd[%d]", e->fd);
 	if (inherit_fd_lookup_id(inh_id) < 0) {
 		fdesc->fds_inherited = FDIH_UNINHERITED;
 	} else if (fdesc->fds_inherited == FDIH_UNKNOWN) {
@@ -1116,7 +1117,7 @@ int setup_and_serve_out(struct fdinfo_list_entry *fle, int new_fd)
 	struct file_desc *d = fle->desc;
 	pid_t pid = fle->pid;
 
-	if (reopen_fd_as(fle->fe->fd, new_fd))
+	if (reopen_fd_as_nocheck(fle->fe->fd, new_fd))
 		return -1;
 
 	if (fcntl(fle->fe->fd, F_SETFD, fle->fe->flags) == -1) {

--- a/criu/pipes.c
+++ b/criu/pipes.c
@@ -110,7 +110,8 @@ static int mark_pipe_master_cb(struct pprep_head *ph)
 
 			list_move(&pic->list, &head);
 			f = file_master(&pic->d);
-			if (fdinfo_rst_prio(f, fle)) {
+			/* Pipe that is going to inherit can't be a master */
+			if (fdinfo_rst_prio(f, fle) || p->d.fds_inherited >= FDIH_FROM_0) {
 				p = pic;
 				fle = f;
 			}


### PR DESCRIPTION
The snprintf-fix addresses invalid merge with crac 3.14; the code was comparing recorded FDs to be inherited with uninitalized on-stack memory.

Using `reopen_fd_as_nocheck` needs a bit more insight to validate; maybe a proper fix would be elsewhere. When stdout (FD 1) is redirected to a file, this code receives `new_fd` set to FD 3 and fails as `fle->fe->fd == 1` is open FD.