### PR TITLE
Don't put restored process on foreground if we are background process

### DIFF
--- a/criu/tty.c
+++ b/criu/tty.c
@@ -689,7 +689,6 @@ static int tty_set_sid(int fd)
 
 static int tty_set_prgp(int fd, int group)
 {
-
 	if (ioctl(fd, TIOCSPGRP, &group)) {
 #if 1
 		if (tolerate_tty_error(fd)) {
@@ -1066,7 +1065,9 @@ out:
 		 * the process which keeps the master peer.
 		 */
 		if (root_item->sid != vpid(root_item)) {
-			if (root_item->pgid == vpid(root_item)) {
+			if (getppid() != tcgetpgrp(0)) {
+				pr_debug("Running in background, not setting foreground process");
+			} else if (root_item->pgid == vpid(root_item)) {
 				if (tty_set_prgp(fd, root_item->pgid))
 					goto err;
 			} else {


### PR DESCRIPTION
When the restore is executed in background (e.g. using `java -XX:CRaCRestoreFrom=... &`) and the restored process receives foreground forcefully, when this exits the parent shell (not on foreground) tries to read input and receives EOF, subsequently exiting. For users this might look as if the bash terminal gets suddenly closed for no reason at all.
