### PR TITLE
Fix /proc/<pid>/cmdline and environ

### DIFF
--- a/include/common/arch/aarch64/asm/page.h
+++ b/include/common/arch/aarch64/asm/page.h
@@ -30,7 +30,6 @@ static inline unsigned page_shift(void)
  * page_size() across sources (as it may differ on aarch64).
  */
 #define PAGE_SIZE  page_size()
-#define PAGE_MASK  (~(PAGE_SIZE - 1))
 #define PAGE_SHIFT page_shift()
 
 #define PAGE_PFN(addr) ((addr) / PAGE_SIZE)
@@ -41,4 +40,7 @@ extern unsigned page_size(void);
 #define PAGE_SIZE page_size()
 
 #endif /* CR_NOGLIBC */
+
+#define PAGE_MASK  (~(PAGE_SIZE - 1))
+
 #endif /* __CR_ASM_PAGE_H__ */


### PR DESCRIPTION
When the addresses set by PR_SET_MM_ARG_START|END and PR_SET_MM_ENV_START|END are mapped to a file (which is the case after mmaping the image into memory) the proc filesystem won't print cmdline and environ correctly.
