### PR TITLE
Require CAP_SYS_RESOURCE for restore

### DIFF
--- a/criu/pie/restorer.c
+++ b/criu/pie/restorer.c
@@ -1800,8 +1800,7 @@ long __export_restore_task(struct task_restore_args *args)
 		ret |= restore_self_exe_late(args);
 
 		if (ret) {
-			pr_warn("Ignoring restore_task error 1 %ld\n", ret);
-			ret = 0;
+			pr_warn("Failures above might be caused by missing CAP_SYS_RESOURCE\n");
 		}
 	} else {
 		if (ret)


### PR DESCRIPTION
While most of the settings set through prctl(PR_SET_MM, ...) have mainly informative value, PR_SET_MM_BRK affects return value of brk syscall. Some applications might behave incorrectly or crash when the syscall returns unexpected value and does not allocate any memory, therefore it is not safe to ignore the error.
