### PR TITLE
vdso-compat: Increase the reserved buffer for compat vdso

### DIFF
--- a/criu/vdso.c
+++ b/criu/vdso.c
@@ -479,7 +479,7 @@ out_close:
 	return ret;
 }
 
-#define COMPAT_VDSO_BUF_SZ (PAGE_SIZE * 2)
+#define COMPAT_VDSO_BUF_SZ (PAGE_SIZE * 4)
 static int vdso_fill_compat_symtable(struct vdso_maps *native, struct vdso_maps *compat)
 {
 	void *vdso_mmap;


### PR DESCRIPTION
**What this does:**
This PR cherry-picks upstream commit checkpoint-restore/criu@70a9cd6, which increases the reserved VDSO buffer size from 2 pages to 4 pages.

**Why it’s needed:**
After upgrading COS nodes in GKE to version 1.31 (kernel 6.6.72+), CRaC fails to restore a snapshot with the following error: `Error: Compatible vdso's size is bigger than reserved buf`
Details in the email thread:
https://mail.openjdk.org/pipermail/crac-dev/2025-May/002433.html

**Original commit message:**
On Arch Linux with 5.18.3-zen1-1-zen kernel, the vdso's size is 3 pages which exceeds the current 2-page reserved buffer. This commit simply increases the reserved buffer size to 4 pages.
Fixes: https://github.com/checkpoint-restore/criu/issues/1916


<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
