### PR TITLE
Support for vvar_vclock VMA

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -29,30 +29,27 @@ jobs:
           done
 
       - name: Start build container
-        run: echo ${GITHUB_TOKEN} | docker login -u ${GITHUB_ACTOR} --password-stdin docker.pkg.github.com;
+        run:
           docker run -d --name build
           -w $PWD
           -v /home/runner:/home/runner
           -u $(id -u):$(id -g)
           --entrypoint tail
-          docker.pkg.github.com/crac/docker-build/image:ubuntu-16.04
+          ghcr.io/crac/docker-build/image:ubuntu-16.04
           -f /dev/null
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/checkout@v2
-
-      - name: Submodule init
-        run: |
-          git submodule init
-          git submodule update
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
       - run: make DESTDIR=. PREFIX=/${{ steps.compute.outputs.BUNDLENAME }} install-criu V=1
         shell: docker exec build bash -e {0}
 
       - run: tar -zcf ${{ steps.compute.outputs.BUNDLENAME }}.tar.gz ${{ steps.compute.outputs.BUNDLENAME }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: ${{ steps.compute.outputs.BUNDLENAME }}
           path: ${{ steps.compute.outputs.BUNDLENAME }}.tar.gz
@@ -62,10 +59,10 @@ jobs:
     needs: build
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: ${{ needs.build.outputs.BUNDLENAME }}
-      - uses: softprops/action-gh-release@v1
+      - uses: softprops/action-gh-release@v2
         with:
           files: |
             ${{ needs.build.outputs.BUNDLENAME }}.tar.gz

--- a/criu/include/util-vdso.h
+++ b/criu/include/util-vdso.h
@@ -30,6 +30,7 @@ struct vdso_symbol {
 struct vdso_symtable {
 	unsigned long vdso_size;
 	unsigned long vvar_size;
+	unsigned long vvar_vclock_size;
 	struct vdso_symbol symbols[VDSO_SYMBOL_MAX];
 	bool vdso_before_vvar; /* order of vdso/vvar pair */
 };

--- a/criu/proc_parse.c
+++ b/criu/proc_parse.c
@@ -557,7 +557,8 @@ static int handle_vma(pid_t pid, struct vma_area *vma_area, const char *file_pat
 	} else if (!strcmp(file_path, "[vdso]")) {
 		if (handle_vdso_vma(vma_area))
 			goto err;
-	} else if (!strcmp(file_path, "[vvar]")) {
+	} else if (!strcmp(file_path, "[vvar]") ||
+		   !strcmp(file_path, "[vvar_vclock]")) {
 		if (handle_vvar_vma(vma_area))
 			goto err;
 	} else if (!strcmp(file_path, "[heap]")) {
@@ -750,7 +751,7 @@ static int task_size_check(pid_t pid, VmaEntry *entry)
 
 int parse_smaps(pid_t pid, struct vm_area_list *vma_area_list, dump_filemap_t dump_filemap)
 {
-	struct vma_area *vma_area = NULL;
+	struct vma_area *vma_area = NULL, *prev_vma_area = NULL;
 	unsigned long start, end, pgoff, prev_end = 0;
 	char r, w, x, s;
 	int ret = -1, vm_file_fd = -1;
@@ -792,8 +793,22 @@ int parse_smaps(pid_t pid, struct vm_area_list *vma_area_list, dump_filemap_t du
 				continue;
 		}
 
-		if (vma_area && vma_list_add(vma_area, vma_area_list, &prev_end, &vfi, &prev_vfi))
-			goto err;
+		if (vma_area && vma_area_is(vma_area, VMA_AREA_VVAR) &&
+		    prev_vma_area && vma_area_is(prev_vma_area, VMA_AREA_VVAR)) {
+			if (prev_vma_area->e->end != vma_area->e->start) {
+				pr_err("two nonconsecutive vvar vma-s: "
+				       "%" PRIx64 "-%" PRIx64 " %" PRIx64 "-%" PRIx64 "\n",
+				       prev_vma_area->e->start, prev_vma_area->e->end,
+				       vma_area->e->start, vma_area->e->end);
+				goto err;
+			}
+			/* Merge all vvar vma-s into one. */
+			prev_vma_area->e->end = vma_area->e->end;
+		} else {
+			if (vma_area && vma_list_add(vma_area, vma_area_list, &prev_end, &vfi, &prev_vfi))
+				goto err;
+			prev_vma_area = vma_area;
+		}
 
 		if (eof)
 			break;


### PR DESCRIPTION
Brings two commits from upstream CRIU that add support for `vvar_vclock` VMA. Without them on Linux/x86 6.13+ checkpoint fails with the below errors which we now see in OpenJDK CI:
```
(00.025701) Error (criu/vdso.c:381): vdso: Unexpected rt vDSO area bounds
(00.025703) Error (criu/vdso.c:613): vdso: Failed to fill self vdso symtable
(00.025703) Error (criu/kerndat.c:1607): kerndat_vdso_fill_symtable failed when initializing kerndat.
(00.025746) Error (criu/crtools.c:260): Could not initialize kernel features detection.
```

Also updates the GHA workflow to use `ghcr.io` instead of the retired `docker.pkg.github.com`.